### PR TITLE
Clarify default output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 Usage
 
-Default Output Folder (Parent Folder)
+Default Output Folder (`<input_folder>-anonymized`)
 
-```
+```bash
 python cli.py /path/to/input/folder
 ```
 
+The anonymized DICOM files will be written to `/path/to/input/folder-anonymized`.
+
 Custom Output Folder
 
-```
+```bash
 python cli.py /path/to/input/folder /path/to/output/folder
 ```


### PR DESCRIPTION
## Summary
- document that the CLI saves to `<input_folder>-anonymized` when no output dir is given

## Testing
- `git log -1 --stat`
